### PR TITLE
Fix for protocol config parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.1
+
+* Fix handling of protocol parameter from config
+
 # 1.0.0
 
 * Drop Python 2.7 support

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -18,6 +18,11 @@
   protocol:
     description: "MQTT protocol version. Default MQTTv311"
     type: "string"
+    enum:
+    - MQTTv3
+    - MQTTv311
+    - MQTTv5
+    default: MQTTv311
     required: false
     secret: false
   client_id:

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@
 ref: mqtt
 name: mqtt
 description: MQTT Integration for StackStorm
-version: 1.0.0
+version: 1.0.1
 author: James Fryman
 email: james@stackstorm.com
 python_versions:

--- a/sensors/mqtt_sensor.py
+++ b/sensors/mqtt_sensor.py
@@ -22,10 +22,7 @@ class MQTTSensor(Sensor):
         self._client = None
         self._hostname = self._config.get('hostname', None)
         self._port = self._config.get('port', 1883)
-        # NOTE: Need to translate MQTT* names into values expected by paho
-        # Default to MQTTv311 if value is not valid since we can't
-        # enforce "allowed" values from the pack config schema
-        self._protocol = getattr(mqtt, self._config.get('protocol', ''), mqtt.MQTTv311)
+        self._protocol = self._config.get('protocol', 'MQTTv311')
         self._client_id = self._config.get('client_id', None)
         self._userdata = self._config.get('userdata', None)
         self._username = self._config.get('username', None)
@@ -39,8 +36,11 @@ class MQTTSensor(Sensor):
     def setup(self):
         self._logger.debug('[MQTTSensor]: setting up sensor...')
 
+        # NOTE: Need to ensure `protocol` MQTT* names are properly
+        # handled as paho.mqtt constants and not bare strings
         self._client = mqtt.Client(self._client_id, clean_session=True,
-                             userdata=self._userdata, protocol=self._protocol)
+                                   userdata=self._userdata,
+                                   protocol=getattr(mqtt, self._protocol))
 
         if self._username:
             self._client.username_pw_set(self._username, password=self._password)

--- a/sensors/mqtt_sensor.py
+++ b/sensors/mqtt_sensor.py
@@ -37,7 +37,7 @@ class MQTTSensor(Sensor):
         self._logger.debug('[MQTTSensor]: setting up sensor...')
 
         self._client = mqtt.Client(self._client_id, clean_session=True,
-                             userdata=self._userdata, protocol=self._protocol)
+                             userdata=self._userdata, protocol=getattr(mqtt, self._protocol))
 
         if self._username:
             self._client.username_pw_set(self._username, password=self._password)

--- a/sensors/mqtt_sensor.py
+++ b/sensors/mqtt_sensor.py
@@ -22,7 +22,10 @@ class MQTTSensor(Sensor):
         self._client = None
         self._hostname = self._config.get('hostname', None)
         self._port = self._config.get('port', 1883)
-        self._protocol = self._config.get('protocol', 'MQTTv311')
+        # NOTE: Need to translate MQTT* names into values expected by paho
+        # Default to MQTTv311 if value is not valid since we can't
+        # enforce "allowed" values from the pack config schema
+        self._protocol = getattr(mqtt, self._config.get('protocol', ''), mqtt.MQTTv311)
         self._client_id = self._config.get('client_id', None)
         self._userdata = self._config.get('userdata', None)
         self._username = self._config.get('username', None)
@@ -37,7 +40,7 @@ class MQTTSensor(Sensor):
         self._logger.debug('[MQTTSensor]: setting up sensor...')
 
         self._client = mqtt.Client(self._client_id, clean_session=True,
-                             userdata=self._userdata, protocol=getattr(mqtt, self._protocol))
+                             userdata=self._userdata, protocol=self._protocol)
 
         if self._username:
             self._client.username_pw_set(self._username, password=self._password)


### PR DESCRIPTION
need `getattr` to allow use of string values as expected by `paho.mqtt.Client()`

This should fix #3 