### PR TITLE
Fix protocol handling in `publish` action; update for v5 support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# 1.0.2
+
+* Fix publish action protocol parameter handling
+* Fix exception in `mqtt.Client()` when using v5 protocol, don't pass
+  `clean_session` parameter.
+* Add `properties` parameter to sensor `_on_connect()` to support v5 protocol.
+
 # 1.0.1
 
 * Fix handling of protocol parameter from config
@@ -18,4 +25,4 @@
 
 # 0.1.0
 
-- First release 
+- First release

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,12 @@
 # Change Log
 
-# 1.0.2
+# 1.1.0
 
 * Fix publish action protocol parameter handling
-* Fix exception in `mqtt.Client()` when using v5 protocol, don't pass
+* Improve v5 protocol support:
+  * Fix exception in `mqtt.Client()` when using v5 protocol, don't pass
   `clean_session` parameter.
-* Add `properties` parameter to sensor `_on_connect()` to support v5 protocol.
+  * Add `properties` parameter to sensor `_on_connect()` to support v5 protocol.
 
 # 1.0.1
 

--- a/actions/publish.py
+++ b/actions/publish.py
@@ -1,4 +1,5 @@
 from st2common.runners.base_action import Action
+import paho.mqtt.client as paho
 import paho.mqtt.publish as publish
 
 
@@ -53,4 +54,4 @@ class PublishAction(Action):
                        hostname=self._hostname, port=self._port,
                        client_id=self._client_id, keepalive=60,
                        auth=self._auth_payload, tls=self._ssl_payload,
-                       protocol=self._protocol)
+                       protocol=getattr(paho, self._protocol))

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@
 ref: mqtt
 name: mqtt
 description: MQTT Integration for StackStorm
-version: 1.0.2
+version: 1.1.0
 author: James Fryman
 email: james@stackstorm.com
 python_versions:

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@
 ref: mqtt
 name: mqtt
 description: MQTT Integration for StackStorm
-version: 1.0.1
+version: 1.0.2
 author: James Fryman
 email: james@stackstorm.com
 python_versions:


### PR DESCRIPTION
Follow up to PR #6: was so focused on sensor code that I forget to make the same fixes to `actions/publish.py`

Also bonus changes to try to make this work properly with MQTT v5 (neither of these are very well documented in the [paho-mqtt pydocs](https://pypi.org/project/paho-mqtt/)):
* use `clean_session` in `Client()` only when using MQTTv31 or MQTTv311 protocols (if used with v5 it will cause `paho.mqtt.client` to throw an exception)
* add `properties` parameter to `_on_session()` as this is expected by v5.