### PR TITLE
Add support for MQTT websockets transport / make `subscribe` parameter optional (to prevent sensor startup)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+# 1.2.0
+
+* Add `transport` config parameter to allow connecting to MQTT broker via websockets.
+* Make `subscribe` parameter optional, if not set then don't start MQTTSensor
+* Cleanup example config file
 # 1.1.0
 
 * Fix publish action protocol parameter handling

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ to `/opt/stackstorm/configs/mqtt.yaml` and edit as required.
 * `ssl_cacert` - Path to SSL CA Certificate
 * `ssl_cert` - Path to SSL Certificate
 * `ssl_key` - Path to SSL Key
+* `transport` - MQTT transport. Can be `tcp` or `websockets` (default: tcp)
 
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can also use dynamic values from the datastore. See the
 Connects to a MQTT broker, subscribing to various topics and emitting triggers
 into the system.
 
-Requires: config setting `subscribe`.
+Requires: config setting `subscribe`.  (if not set sensor will not be started)
 Emits:
   * trigger: mqtt.message
   * payload: topic, message, userdata, qos, retain

--- a/actions/publish.py
+++ b/actions/publish.py
@@ -23,6 +23,7 @@ class PublishAction(Action):
         self._ssl_cacert = self._config.get('ssl_cacert', None)
         self._ssl_cert = self._config.get('ssl_cert', None)
         self._ssl_key = self._config.get('ssl_key', None)
+        self._transport = self._config.get('transport', 'tcp')
 
         self._ssl_payload = None
         self._auth_payload = None
@@ -54,4 +55,5 @@ class PublishAction(Action):
                        hostname=self._hostname, port=self._port,
                        client_id=self._client_id, keepalive=60,
                        auth=self._auth_payload, tls=self._ssl_payload,
-                       protocol=getattr(paho, self._protocol))
+                       protocol=getattr(paho, self._protocol),
+                       transport=self._transport)

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -66,3 +66,12 @@
     type: "string"
     required: false
     secret: false
+  transport:
+    description: "MQTT transport mechanism. Default: tcp"
+    type: "string"
+    enum:
+    - tcp
+    - websockets
+    default: "tcp"
+    required: false
+    secret: false

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -9,7 +9,7 @@
     type: "array"
     items:
       type: "string"
-    required: true
+    required: false
   port:
     description: "MQTT port to connect to. Default 1883"
     type: "integer"

--- a/mqtt.yaml.example
+++ b/mqtt.yaml.example
@@ -1,4 +1,4 @@
-### Place configuration data for your pack here.
+### Configuration data for the MQTT pack.
 ---
 hostname: ''
 subscribe:
@@ -7,9 +7,12 @@ subscribe:
 ## Optional Parameters
 # client_id: ""
 # port: 1833
+# protocol: "<MQTTv3|MQTTv311|MQTTv5>"
 # username: ""
 # password: ""
+# userdata: ""
 # ssl: true
 # ssl_cacert: ""
 # ssl_cert: ""
 # ssl_key: ""
+# transport: "<tcp|websockets>"

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,9 +1,8 @@
-### Place information about your pack version here.
 ---
 ref: mqtt
 name: mqtt
 description: MQTT Integration for StackStorm
-version: 1.1.0
+version: 1.2.0
 author: James Fryman
 email: james@stackstorm.com
 python_versions:

--- a/sensors/mqtt_sensor.py
+++ b/sensors/mqtt_sensor.py
@@ -37,6 +37,12 @@ class MQTTSensor(Sensor):
     def setup(self):
         self._logger.debug('[MQTTSensor]: setting up sensor...')
 
+        # if no topics are configured for subscription, then don't run
+        # the sensor
+        if not self._subscribe:
+            raise ValueError(
+                'MQTTSensor requires at least one subscription topic')
+
         # NOTE: Need to ensure `protocol` MQTT* names are properly
         # handled as paho.mqtt constants and not bare strings
         protocol = getattr(mqtt, self._protocol)
@@ -80,7 +86,8 @@ class MQTTSensor(Sensor):
 
     def cleanup(self):
         self._logger.debug('[MQTTSensor]: entering cleanup')
-        self._client.disconnect()
+        if self._client:
+            self._client.disconnect()
 
     def add_trigger(self, trigger):
         pass

--- a/sensors/mqtt_sensor.py
+++ b/sensors/mqtt_sensor.py
@@ -32,6 +32,7 @@ class MQTTSensor(Sensor):
         self._ssl_cacert = self._config.get('ssl_cacert', None)
         self._ssl_cert = self._config.get('ssl_cert', None)
         self._ssl_key = self._config.get('ssl_key', None)
+        self._transport = self._config.get('transport', 'tcp')
 
     def setup(self):
         self._logger.debug('[MQTTSensor]: setting up sensor...')
@@ -45,7 +46,7 @@ class MQTTSensor(Sensor):
         clargs = {'clean_session': True} if protocol in [mqtt.MQTTv31, mqtt.MQTTv311] else {}
 
         self._client = mqtt.Client(self._client_id, userdata=self._userdata,
-                                   protocol=protocol, **clargs)
+                                   protocol=protocol, transport=self._transport, **clargs)
 
         if self._username:
             self._client.username_pw_set(self._username, password=self._password)
@@ -63,8 +64,8 @@ class MQTTSensor(Sensor):
                 raise ValueError('[mqtt_sensor]: Missing "ssl_key" \
                                     config option')
 
-            self._client.tls_set(self._ssl_cacert, certfile=self._ssl_cert,
-                                keyfile=self._ssl_key)
+            self._client.tls_set(ca_certs=self._ssl_cacert, certfile=self._ssl_cert,
+                                 keyfile=self._ssl_key)
 
         # Wire up the adapter with the appropriate callback methods
         self._client.on_connect = self._on_connect


### PR DESCRIPTION
This PR adds some basic support for using websockets transport (instead of tcp) to connect to MQTT.  Set the `transport` config parameter to `websockets` to use this.

Note that I didn't currently implement the `ws_set_options()` function for websockets as provided by [paho-mqtt](https://pypi.org/project/paho-mqtt/#option-functions)

I also made the `subscribe` config parameter optional, if it is not defined then the `MQTTSensor` will not attempt to start up (this is for my particular use case where I am only interested in publishing to MQTT via the `mqtt.publish` action but not subscribing/watching any particular topics)